### PR TITLE
Title: Implement Property Filtering (Backend) #4

### DIFF
--- a/backend/app/api/endpoints/property_routes.py
+++ b/backend/app/api/endpoints/property_routes.py
@@ -16,8 +16,22 @@ def create(data: PropertyCreate, db: Session = Depends(get_db)):
 
 
 @router.get("/", response_model=List[PropertyResponse])
-def get_all(db: Session = Depends(get_db)):
-    return property_service.get_all_properties(db)
+def get_all(
+    location: str = None,
+    property_type: str = None,
+    min_price: float = None,
+    max_price: float = None,
+    bedrooms: int = None,
+    db: Session = Depends(get_db),
+):
+    return property_service.get_all_properties(
+        db,
+        location=location,
+        property_type=property_type,
+        min_price=min_price,
+        max_price=max_price,
+        bedrooms=bedrooms,
+    )
 
 
 @router.get("/{property_id}", response_model=PropertyResponse)

--- a/backend/app/services/property_service.py
+++ b/backend/app/services/property_service.py
@@ -13,8 +13,28 @@ def create_property(db: Session, data: PropertyCreate) -> Property:
     return db_property
 
 
-def get_all_properties(db: Session) -> list[Property]:
-    return db.query(Property).all()
+def get_all_properties(
+    db: Session,
+    location: str = None,
+    property_type: str = None,
+    min_price: float = None,
+    max_price: float = None,
+    bedrooms: int = None,
+) -> list[Property]:
+    query = db.query(Property)
+
+    if location:
+        query = query.filter(Property.location.ilike(f"%{location}%"))
+    if property_type:
+        query = query.filter(Property.property_type == property_type)
+    if min_price is not None:
+        query = query.filter(Property.price >= min_price)
+    if max_price is not None:
+        query = query.filter(Property.price <= max_price)
+    if bedrooms is not None:
+        query = query.filter(Property.bedrooms == bedrooms)
+
+    return query.all()
 
 
 def get_property_by_id(db: Session, property_id: int) -> Property:


### PR DESCRIPTION
## Description
Extends the Property API to support advanced filtering via query parameters. This allows users to narrow down property listings by location, price range, type, and bedroom count directly from the GET /properties endpoint.

## Changes
- **Dynamic Query Building:** Refactored the service layer to use a chainable SQLAlchemy query.
- **Case-Insensitive Search:** Implemented `.ilike()` for location filtering to support broader search results.
- **Query Parameters:** Added optional parameters to the FastAPI route to ensure type safety and automatic documentation in Swagger.

## Example Usage
- `GET /properties?location=Lekki&min_price=50000000`
- `GET /properties?bedrooms=3&property_type=rent`

Closes #4
